### PR TITLE
Updated BoundsNode.retrieve method to work with bounds

### DIFF
--- a/JavaScript/QuadTree/src/QuadTree.js
+++ b/JavaScript/QuadTree/src/QuadTree.js
@@ -370,13 +370,61 @@ BoundsNode.prototype.retrieve = function(item)
 	if(this.nodes.length)
 	{
 		var index = this._findIndex(item);
+		var node = this.nodes[index];
 		
-		out.push.apply(out, this.nodes[index].retrieve(item));
+		if(item.x >= node._bounds.x &&
+			item.x + item.width <= node._bounds.x + node._bounds.width &&
+			item.y >= node._bounds.y &&
+			item.y + item.height <= node._bounds.y + node._bounds.height)
+		{
+			out.push.apply(out, this.nodes[index].retrieve(item));
+		}
+		else //Part of the item are overlapping multiple child nodes. For each of the overlapping nodes, return all containing objects.
+		{
+			
+	
+			
+			if(item.x <= this.nodes[Node.TOP_RIGHT]._bounds.x){
+				if(item.y <= this.nodes[Node.BOTTOM_LEFT]._bounds.y){
+							out.push.apply(out, this.nodes[Node.TOP_LEFT].getAllContent());
+				}
+				if(item.y + item.height > this.nodes[Node.BOTTOM_LEFT]._bounds.y){
+							out.push.apply(out, this.nodes[Node.BOTTOM_LEFT].getAllContent());
+				}
+
+			}
+			if(item.x + item.width > this.nodes[Node.TOP_RIGHT]._bounds.x){//position+width bigger than middle x
+				if(item.y <= this.nodes[Node.BOTTOM_RIGHT]._bounds.y){
+							out.push.apply(out, this.nodes[Node.TOP_RIGHT].getAllContent());
+				}
+				if(item.y + item.height > this.nodes[Node.BOTTOM_RIGHT]._bounds.y){
+							out.push.apply(out, this.nodes[Node.BOTTOM_RIGHT].getAllContent());
+				}
+
+			}
+			
+			
+		}
+		
+		
 	}
 	
 	out.push.apply(out, this._stuckChildren);
 	out.push.apply(out, this.children);
 	
+	return out;
+}
+
+//Returns all contents of node.
+BoundsNode.prototype.getAllContent = function(){
+	var out = this._out;
+	if(this.nodes.length){
+		for(var i=0;i<this.nodes.length;i++){
+			this.nodes[i].getAllContent();	
+		}	
+	}
+	out.push.apply(out, this._stuckChildren);
+	out.push.apply(out, this.children);
 	return out;
 }
 


### PR DESCRIPTION
The BoundsNode.retrieve method did not take width and height of the lookup item in consideration.

Now it will. When part of the item overlaps multiple child nodes, the contents of all overlapping child nodes are returned, instead of just the one where the top left corner is.
