### PR TITLE
- Removed floor in 'subdivide' function. When trying to build quadtrees ...

### DIFF
--- a/JavaScript/QuadTree/src/QuadTree.js
+++ b/JavaScript/QuadTree/src/QuadTree.js
@@ -219,8 +219,8 @@
         var by = this._bounds.y;
 
         //floor the values
-        var b_w_h = (this._bounds.width / 2) | 0; //todo: Math.floor?
-        var b_h_h = (this._bounds.height / 2) | 0;
+        var b_w_h = (this._bounds.width / 2); //todo: Math.floor?
+        var b_h_h = (this._bounds.height / 2);
         var bx_b_w_h = bx + b_w_h;
         var by_b_h_h = by + b_h_h;
 


### PR DESCRIPTION
...in applications with high precision (a google map's lat/lng measurements, for instance), this was causing the quadtree to never create more than one subdivision or point, unless, of course, the points were far enough apart to pass the bitshift operation intact
